### PR TITLE
Added name of module to data.classes

### DIFF
--- a/MMM-Weather-Now.js
+++ b/MMM-Weather-Now.js
@@ -21,8 +21,8 @@ Module.register('MMM-Weather-Now', {
         Log.log('Starting module: ' + this.name);
 
         if (this.data.classes === 'MMM-Weather-Now') {
-            this.data.classes = 'bright medium';
-            }
+            this.data.classes = 'MMM-Weather-Now bright medium';
+        }
 
         // Set up the local values, here we construct the request url to use
         this.units = this.config.units;


### PR DESCRIPTION
The name of the module is required in `this.data.classes` for the Magic Mirror framework to successfully hide and show modules. Not having the module name in said field breaks module visibility management.

This bug was discovered from a user reporting breaking behavior in edward-shen/MMM-pages#8. 

I think it's better practice to write your DOM properties in a container div in getDom rather than directly modifying the property. I'm pretty sure it's suppose to be a readonly property.