### PR TITLE
Fix equality check

### DIFF
--- a/MMM-Weather-Now.js
+++ b/MMM-Weather-Now.js
@@ -63,7 +63,7 @@ Module.register('MMM-Weather-Now', {
 		var C = '--';
 		var F = '--';
 		if (this.nowTemp !== '--') {
-			if (this.units = 'M') {
+			if (this.units === 'M') {
 				C = this.nowTemp;
 				F = Math.round( (((C*9)/5)+32) * 10 ) / 10;
 			} else {


### PR DESCRIPTION
Previously, `this.units` was being set to `'M'`, overriding the value provided in a users config, and causing incorrect values to be displayed for users using imperial units. 

Previous:
![image](https://user-images.githubusercontent.com/21086745/46577164-7e883a80-c994-11e8-9111-3c518329c2f0.png)

After:
![image](https://user-images.githubusercontent.com/21086745/46577167-8fd14700-c994-11e8-8555-6d2d3704fb97.png)
